### PR TITLE
Fixed issue where disclosure creation errored if no tags were applied

### DIFF
--- a/app/models/disclosure.rb
+++ b/app/models/disclosure.rb
@@ -3,9 +3,13 @@ class Disclosure < ActiveRecord::Base
   has_many :tags, through: :disclosure_tags
 
   def create_tags(params)
-    params.each do |tag|
-      self.disclosure_tags.create(tag_id: tag[1])
+    if params
+      params.each do |tag|
+        self.disclosure_tags.create(tag_id: tag[1])
+      end
+      self.disclosure_tags.all? { |tag| tag.save }
+    else
+      true # returns true if there are no tags to save
     end
-    self.disclosure_tags.all? { |tag| tag.save }
   end
 end


### PR DESCRIPTION
The disclosure model was attempting to save associated tags, even if the user didn't add any tags to it.