### PR TITLE
Create a filter to prevent reaccepting terms

### DIFF
--- a/app/controllers/accept_terms_controller.rb
+++ b/app/controllers/accept_terms_controller.rb
@@ -1,4 +1,6 @@
 class AcceptTermsController < ApplicationController
+	before_filter :check_if_terms_accepted
+	
 	def edit
 	end
 
@@ -7,7 +9,15 @@ class AcceptTermsController < ApplicationController
 			Rails.logger.info "that's consent"
 			current_user.accepted_terms = true
 			current_user.save
-			redirect_to '/innovations/new'
+			redirect_to new_innovation_path
+		end
+	end
+	
+	private
+	
+	def check_if_terms_accepted
+		if current_user.accepted_terms
+			redirect_to root
 		end
 	end
 end


### PR DESCRIPTION
In order to prevent users from updating their accepted_terms_at timestamp, prevent them from being able to submit the accept terms form twice.